### PR TITLE
Fix state column bug

### DIFF
--- a/lib/ecto_as_state_machine/state.ex
+++ b/lib/ecto_as_state_machine/state.ex
@@ -10,7 +10,7 @@ defmodule EctoAsStateMachine.State do
   @spec update(%{event: List.t(), model: Map.t(), states: List.t(), initial: String.t(), column: atom}) :: term | %{valid: false}
   def update(%{event: event, model: model, states: states, initial: initial, column: column}) do
     model
-    |> Changeset.change(%{state: "#{event[:to]}"})
+    |> Changeset.change(%{column => "#{event[:to]}"})
     |> run_callback(event[:callback])
     |> validate_state_transition(%{
       event: event,

--- a/test/ecto_as_state_machine/state_test.exs
+++ b/test/ecto_as_state_machine/state_test.exs
@@ -61,6 +61,17 @@ defmodule EctoAsStateMachine.StateTest do
         initial: @initial})
       assert match?(%{valid?: false}, value)
     end
+
+    it "with new state and custom column name", context do
+      other_states = [:unfirmed, :firmed]
+      other_event = [
+        name:     :firm,
+        from:     [:unfirmed],
+        to:       :firmed,
+      ]
+      value = EctoAsStateMachine.State.update(%{event: other_event, states: other_states, model: context[:unconfirmed_user], initial: "unfirmed", column: :some})
+      assert match? %{changes: %{some: "firmed"}}, value
+    end
   end
 
   describe ".next_state" do


### PR DESCRIPTION
It turns out that the custom column name was not being respected on update (i.e. via `event_name!`). This adds a failing test for that, and then fixes it.